### PR TITLE
added instructions if unauthorized, also added test

### DIFF
--- a/packages/connectors/hull-hubspot/server/actions/status-check.js
+++ b/packages/connectors/hull-hubspot/server/actions/status-check.js
@@ -5,13 +5,33 @@ const _ = require("lodash");
 
 const SyncAgent = require("../lib/sync-agent");
 
+function getMessageFromError(err): string {
+
+  console.log(err.message);
+  if (err.message && typeof err.message === 'string'
+      && err.message.indexOf("Failed to refresh access token") === 0) {
+    return "Unauthorized response from Hubspot. Please reauthenticate with Hubspot by clicking the \"Credentials and Actions\" button in the upper right hand section of the connector settings.  Then either click \"Continue to Hubspot\" or \"Start over\"";
+  }
+
+  // return either the msg or message parameter from err
+  return `Could not get response from Hubspot due to error ${_.get(
+    err,
+    "msg",
+    _.get(err, "message", "")
+  )}`;
+}
+
 function statusCheckAction(ctx: HullContext) {
   const { connector = {}, client = {} } = ctx;
   const messages = [];
   let status = "ok";
   const pushMessage = message => {
     status = "error";
-    messages.push(message);
+
+    // make sure the message isn't already in the list...
+    if (messages.indexOf(message) < 0) {
+      messages.push(message);
+    }
   };
   const promises = [];
 
@@ -52,13 +72,7 @@ function statusCheckAction(ctx: HullContext) {
           }
         })
         .catch(err => {
-          pushMessage(
-            `Could not get response from Hubspot due to error ${_.get(
-              err,
-              "msg",
-              _.get(err, "message", "")
-            )}`
-          );
+          pushMessage(getMessageFromError(err));
         })
     );
     promises.push(
@@ -84,13 +98,7 @@ function statusCheckAction(ctx: HullContext) {
           }
         })
         .catch(err => {
-          pushMessage(
-            `Could not get response from Hubspot due to error ${_.get(
-              err,
-              "msg",
-              _.get(err, "message", "")
-            )}`
-          );
+          pushMessage(getMessageFromError(err));
         })
     );
   }

--- a/packages/connectors/hull-hubspot/server/actions/status-check.js
+++ b/packages/connectors/hull-hubspot/server/actions/status-check.js
@@ -11,7 +11,7 @@ function getMessageFromError(err): string {
     typeof err.message === "string" &&
     err.message.indexOf("Failed to refresh access token") === 0
   ) {
-    return 'Unauthorized·response·from·Hubspot.·Please·reauthenticate·with·Hubspot·by·clicking·the·"Credentials·and·Actions"·button·in·the·upper·right·hand·section·of·the·connector·settings.··Then·either·click·"Continue·to·Hubspot"·or·"Start·over"';
+    return 'Unauthorized response from Hubspot. Please reauthenticate with Hubspot by clicking the "Credentials and Actions" button in the upper right hand section of the connector settings.  Then either click "Continue to Hubspot" or "Start over"';
   }
 
   // return either the msg or message parameter from err

--- a/packages/connectors/hull-hubspot/server/actions/status-check.js
+++ b/packages/connectors/hull-hubspot/server/actions/status-check.js
@@ -10,8 +10,8 @@ function getMessageFromError(err): string {
     err.message &&
     typeof err.message === "string" &&
     err.message.indexOf("Failed to refresh access token") === 0
-    ) {
-      return 'Unauthorized·response·from·Hubspot.·Please·reauthenticate·with·Hubspot·by·clicking·the·"Credentials·and·Actions"·button·in·the·upper·right·hand·section·of·the·connector·settings.··Then·either·click·"Continue·to·Hubspot"·or·"Start·over"';
+  ) {
+    return 'Unauthorized·response·from·Hubspot.·Please·reauthenticate·with·Hubspot·by·clicking·the·"Credentials·and·Actions"·button·in·the·upper·right·hand·section·of·the·connector·settings.··Then·either·click·"Continue·to·Hubspot"·or·"Start·over"';
   }
 
   // return either the msg or message parameter from err

--- a/packages/connectors/hull-hubspot/server/actions/status-check.js
+++ b/packages/connectors/hull-hubspot/server/actions/status-check.js
@@ -6,11 +6,12 @@ const _ = require("lodash");
 const SyncAgent = require("../lib/sync-agent");
 
 function getMessageFromError(err): string {
-
-  console.log(err.message);
-  if (err.message && typeof err.message === 'string'
-      && err.message.indexOf("Failed to refresh access token") === 0) {
-    return "Unauthorized response from Hubspot. Please reauthenticate with Hubspot by clicking the \"Credentials and Actions\" button in the upper right hand section of the connector settings.  Then either click \"Continue to Hubspot\" or \"Start over\"";
+  if (
+    err.message &&
+    typeof err.message === "string" &&
+    err.message.indexOf("Failed to refresh access token") === 0
+    ) {
+      return 'Unauthorized·response·from·Hubspot.·Please·reauthenticate·with·Hubspot·by·clicking·the·"Credentials·and·Actions"·button·in·the·upper·right·hand·section·of·the·connector·settings.··Then·either·click·"Continue·to·Hubspot"·or·"Start·over"';
   }
 
   // return either the msg or message parameter from err

--- a/packages/connectors/hull-hubspot/test/integration/scenarios/status-unauthorized-bubble-up.js
+++ b/packages/connectors/hull-hubspot/test/integration/scenarios/status-unauthorized-bubble-up.js
@@ -44,8 +44,8 @@ it("Should detect when we try to refresh token and fail with unauthorized", () =
       logs: [
         ["debug", "connector.service_api.call", {}, {"method": "GET", "responseTime": expect.whatever(), "status": 401, "url": "/contacts/v1/lists/recently_updated/contacts/recent", "vars": {}}],
         ["debug", "connector.service_api.call", {}, {"method": "GET", "responseTime": expect.whatever(), "status": 401, "url": "/contacts/v2/groups", "vars": {}}],
-        ["debug", "retrying query", {}, []], ["debug", "access_token", {}, {"expires_at": "2014-12-30T14:17:56-05:00", "expires_in": 10, "fetched_at": "2014-12-30T14:17:46-05:00", "utc_now": expect.whatever(), "will_expire_in": expect.whatever(), "will_expire_soon": true}],
-        ["debug", "retrying query", {}, []], ["debug", "access_token", {}, {"expires_at": "2014-12-30T14:17:56-05:00", "expires_in": 10, "fetched_at": "2014-12-30T14:17:46-05:00", "utc_now": expect.whatever(), "will_expire_in": expect.whatever(), "will_expire_soon": true}],
+        ["debug", "retrying query", {}, []], ["debug", "access_token", {}, {"expires_at": expect.whatever(), "expires_in": 10, "fetched_at": expect.whatever(), "utc_now": expect.whatever(), "will_expire_in": expect.whatever(), "will_expire_soon": true}],
+        ["debug", "retrying query", {}, []], ["debug", "access_token", {}, {"expires_at": expect.whatever(), "expires_in": 10, "fetched_at": expect.whatever(), "utc_now": expect.whatever(), "will_expire_in": expect.whatever(), "will_expire_soon": true}],
         ["debug", "connector.service_api.call", {}, {"method": "POST", "responseTime": expect.whatever(), "status": 400, "url": "/oauth/v1/token", "vars": {}}],
         ["debug", "connector.service_api.call", {}, {"method": "POST", "responseTime": expect.whatever(), "status": 400, "url": "/oauth/v1/token", "vars": {}}]
       ],

--- a/packages/connectors/hull-hubspot/test/integration/scenarios/status-unauthorized-bubble-up.js
+++ b/packages/connectors/hull-hubspot/test/integration/scenarios/status-unauthorized-bubble-up.js
@@ -1,0 +1,86 @@
+// @flow
+/* global describe, it, beforeEach, afterEach */
+const testScenario = require("hull-connector-framework/src/test-scenario");
+const _ = require("lodash");
+
+process.env.CLIENT_ID = "12345";
+process.env.CLIENT_SECRET = "67890";
+
+const connectorServer = require("../../../server/server");
+const connectorManifest = require("../../../manifest");
+
+process.env.OVERRIDE_HUBSPOT_URL = "";
+
+const connector = {
+  private_settings: {
+    token: "hubToken",
+    token_fetched_at: 1419967066626,
+    expires_in: 10,
+    refresh_token: "12345"
+  }
+};
+
+it("Should detect when we try to refresh token and fail with unauthorized", () => {
+  return testScenario({ connectorServer, connectorManifest }, ({ handlers, nock, expect }) => {
+    return {
+      handlerType: handlers.scheduleHandler,
+      handlerUrl: "status",
+      externalApiMock: () => {
+        const scope = nock("https://api.hubapi.com");
+        scope.get("/contacts/v1/lists/recently_updated/contacts/recent?count=100&vidOffset")
+          .reply(401, []);
+        scope.get("/contacts/v2/groups?includeProperties=true")
+          .reply(401, []);
+        scope.post("/oauth/v1/token", "refresh_token=12345&client_id=12345&client_secret=67890&redirect_uri=&grant_type=refresh_token")
+          .reply(400, []);
+        scope.post("/oauth/v1/token", "refresh_token=12345&client_id=12345&client_secret=67890&redirect_uri=&grant_type=refresh_token")
+          .reply(400, []);
+        return scope;
+      },
+      connector,
+      usersSegments: [],
+      accountsSegments: [],
+      response: {"messages": ["Missing portal id.", "No fields are going to be sent from hull to hubspot because of missing configuration.", "No fields are going to be sent from hubspot to hull because of missing configuration.", "Unauthorized response from Hubspot. Please reauthenticate with Hubspot by clicking the \"Credentials and Actions\" button in the upper right hand section of the connector settings.  Then either click \"Continue to Hubspot\" or \"Start over\""], "status": "error"},
+      logs: [
+        ["debug", "connector.service_api.call", {}, {"method": "GET", "responseTime": expect.whatever(), "status": 401, "url": "/contacts/v1/lists/recently_updated/contacts/recent", "vars": {}}],
+        ["debug", "connector.service_api.call", {}, {"method": "GET", "responseTime": expect.whatever(), "status": 401, "url": "/contacts/v2/groups", "vars": {}}],
+        ["debug", "retrying query", {}, []], ["debug", "access_token", {}, {"expires_at": "2014-12-30T14:17:56-05:00", "expires_in": 10, "fetched_at": "2014-12-30T14:17:46-05:00", "utc_now": expect.whatever(), "will_expire_in": expect.whatever(), "will_expire_soon": true}],
+        ["debug", "retrying query", {}, []], ["debug", "access_token", {}, {"expires_at": "2014-12-30T14:17:56-05:00", "expires_in": 10, "fetched_at": "2014-12-30T14:17:46-05:00", "utc_now": expect.whatever(), "will_expire_in": expect.whatever(), "will_expire_soon": true}],
+        ["debug", "connector.service_api.call", {}, {"method": "POST", "responseTime": expect.whatever(), "status": 400, "url": "/oauth/v1/token", "vars": {}}],
+        ["debug", "connector.service_api.call", {}, {"method": "POST", "responseTime": expect.whatever(), "status": 400, "url": "/oauth/v1/token", "vars": {}}]
+      ],
+      firehoseEvents: [],
+      metrics: [
+        ["increment", "connector.request", 1],
+        ["increment", "ship.service_api.call", 1],
+        ["value", "connector.service_api.response_time", expect.whatever()],
+        ["increment", "connector.service_api.error", 1],
+        ["increment", "ship.service_api.call", 1],
+        ["value", "connector.service_api.response_time", expect.whatever()],
+        ["increment", "connector.service_api.error", 1],
+        ["increment", "ship.service_api.call", 1],
+        ["increment", "ship.service_api.call", 1],
+        ["increment", "ship.service_api.call", 1],
+        ["value", "connector.service_api.response_time", expect.whatever()],
+        ["increment", "connector.service_api.error", 1],
+        ["increment", "ship.service_api.call", 1],
+        ["value", "connector.service_api.response_time", expect.whatever()],
+        ["increment", "connector.service_api.error", 1]
+      ],
+      platformApiCalls: [
+        ["PUT", "/api/v1/9993743b22d60dd829001999/status", {},
+          {
+            "messages":
+              [
+                "Missing portal id.",
+                "No fields are going to be sent from hull to hubspot because of missing configuration.",
+                "No fields are going to be sent from hubspot to hull because of missing configuration.",
+                "Unauthorized response from Hubspot. Please reauthenticate with Hubspot by clicking the \"Credentials and Actions\" button in the upper right hand section of the connector settings.  Then either click \"Continue to Hubspot\" or \"Start over\""
+              ],
+            "status": "error"
+          }
+        ]
+      ]
+    };
+  });
+});

--- a/packages/connectors/hull-hubspot/test/integration/scenarios/status-unauthorized-bubble-up.js
+++ b/packages/connectors/hull-hubspot/test/integration/scenarios/status-unauthorized-bubble-up.js
@@ -3,8 +3,8 @@
 const testScenario = require("hull-connector-framework/src/test-scenario");
 const _ = require("lodash");
 
-process.env.CLIENT_ID = "12345";
-process.env.CLIENT_SECRET = "67890";
+process.env.CLIENT_ID = "123";
+process.env.CLIENT_SECRET = "abc";
 
 const connectorServer = require("../../../server/server");
 const connectorManifest = require("../../../manifest");
@@ -16,7 +16,7 @@ const connector = {
     token: "hubToken",
     token_fetched_at: 1419967066626,
     expires_in: 10,
-    refresh_token: "12345"
+    refresh_token: "123"
   }
 };
 
@@ -31,9 +31,9 @@ it("Should detect when we try to refresh token and fail with unauthorized", () =
           .reply(401, []);
         scope.get("/contacts/v2/groups?includeProperties=true")
           .reply(401, []);
-        scope.post("/oauth/v1/token", "refresh_token=12345&client_id=12345&client_secret=67890&redirect_uri=&grant_type=refresh_token")
+        scope.post("/oauth/v1/token", "refresh_token=123&client_id=123&client_secret=abc&redirect_uri=&grant_type=refresh_token")
           .reply(400, []);
-        scope.post("/oauth/v1/token", "refresh_token=12345&client_id=12345&client_secret=67890&redirect_uri=&grant_type=refresh_token")
+        scope.post("/oauth/v1/token", "refresh_token=123&client_id=123&client_secret=abc&redirect_uri=&grant_type=refresh_token")
           .reply(400, []);
         return scope;
       },


### PR DESCRIPTION
Because of the way hubspot-client works, I can't check the thrown error for a 401.  It's because hull-client tries to refresh whenever it sees a 401.  But if the refresh isn't valid, it throws a 400, which is then wrapped in a configuration error with a specific message. 

I'm checking the error for that message, then making sure that we give good instructions on how to recover to the user.  The dependency on the right message is brittle, but I added a unit test in case we ever change it, the unit test should break.
