### PR TITLE
Centralize and factor connectorName for Logs

### DIFF
--- a/packages/connectors/hull-aircall/server/config.js
+++ b/packages/connectors/hull-aircall/server/config.js
@@ -1,7 +1,6 @@
 // @flow
 
 import type { HullConnectorConfig } from "hull";
-import _ from "lodash";
 import manifest from "../manifest.json";
 import fetchToken from "./lib/fetch-token";
 import handlers from "./handlers";
@@ -32,8 +31,7 @@ export default function connectorConfig(): HullConnectorConfig {
       logLevel: LOG_LEVEL
     },
     clientConfig: {
-      firehoseUrl: OVERRIDE_FIREHOSE_URL,
-      connectorName: _.kebabCase(manifest.name)
+      firehoseUrl: OVERRIDE_FIREHOSE_URL
     },
     serverConfig: {
       start: true

--- a/packages/connectors/hull-browser/server/config.js
+++ b/packages/connectors/hull-browser/server/config.js
@@ -1,6 +1,5 @@
 // @flow
 import type { HullConnectorConfig } from "hull";
-import _ from "lodash";
 import manifest from "../manifest.json";
 import handlers from "./handlers";
 
@@ -31,8 +30,7 @@ export default function connectorConfig(): HullConnectorConfig {
       logLevel: LOG_LEVEL
     },
     clientConfig: {
-      firehoseUrl: OVERRIDE_FIREHOSE_URL,
-      connectorName: _.kebabCase(manifest.name)
+      firehoseUrl: OVERRIDE_FIREHOSE_URL
     },
     serverConfig: {
       start: true

--- a/packages/connectors/hull-customerio/server/config.js
+++ b/packages/connectors/hull-customerio/server/config.js
@@ -1,7 +1,6 @@
 // @flow
 
 import type { HullConnectorConfig } from "hull";
-import _ from "lodash";
 import manifest from "../manifest.json";
 import fetchToken from "./lib/fetch-token";
 import handlers from "./handlers";
@@ -30,8 +29,7 @@ export default function connectorConfig(): HullConnectorConfig {
       logLevel: LOG_LEVEL
     },
     clientConfig: {
-      firehoseUrl: OVERRIDE_FIREHOSE_URL,
-      connectorName: _.kebabCase(manifest.name)
+      firehoseUrl: OVERRIDE_FIREHOSE_URL
     },
     serverConfig: {
       start: true

--- a/packages/connectors/hull-front/server/config.js
+++ b/packages/connectors/hull-front/server/config.js
@@ -1,7 +1,6 @@
 // @flow
 
 import type { HullConnectorConfig } from "hull";
-import _ from "lodash";
 import manifest from "../manifest.json";
 import fetchToken from "./lib/fetch-token";
 import handlers from "./handlers";
@@ -32,8 +31,7 @@ export default function connectorConfig(): HullConnectorConfig {
       logLevel: LOG_LEVEL
     },
     clientConfig: {
-      firehoseUrl: OVERRIDE_FIREHOSE_URL,
-      connectorName: _.kebabCase(manifest.name)
+      firehoseUrl: OVERRIDE_FIREHOSE_URL
     },
     serverConfig: {
       start: true

--- a/packages/connectors/hull-hubspot/server/config.js
+++ b/packages/connectors/hull-hubspot/server/config.js
@@ -1,7 +1,6 @@
 // @flow
 
 import type { HullConnectorConfig } from "hull";
-import _ from "lodash";
 import manifest from "../manifest.json";
 import handlers from "./handlers";
 
@@ -48,8 +47,7 @@ export default function connectorConfig(): HullConnectorConfig {
       logLevel: LOG_LEVEL
     },
     clientConfig: {
-      firehoseUrl: OVERRIDE_FIREHOSE_URL,
-      connectorName: _.kebabCase(manifest.name)
+      firehoseUrl: OVERRIDE_FIREHOSE_URL
     }
   };
 }

--- a/packages/connectors/hull-incoming-webhooks/server/config.js
+++ b/packages/connectors/hull-incoming-webhooks/server/config.js
@@ -2,7 +2,6 @@
 
 import type { HullConnectorConfig } from "hull";
 import { entryModel } from "hull-vm";
-import _ from "lodash";
 import manifest from "../manifest.json";
 import fetchToken from "./lib/fetch-token";
 import handlers from "./handlers";
@@ -46,8 +45,7 @@ export default function connectorConfig(): HullConnectorConfig {
       logLevel: LOG_LEVEL
     },
     clientConfig: {
-      firehoseUrl: OVERRIDE_FIREHOSE_URL,
-      connectorName: _.kebabCase(manifest.name)
+      firehoseUrl: OVERRIDE_FIREHOSE_URL
     },
     serverConfig: {
       start: true

--- a/packages/connectors/hull-mailchimp/server/config.js
+++ b/packages/connectors/hull-mailchimp/server/config.js
@@ -1,7 +1,6 @@
 // @flow
 
 import type { HullConnectorConfig } from "hull";
-import _ from "lodash";
 import manifest from "../manifest.json";
 import handlers from "./handlers";
 
@@ -62,8 +61,7 @@ export default function connectorConfig(): HullConnectorConfig {
       queueName: QUEUE_NAME || "queue"
     },
     clientConfig: {
-      firehoseUrl: OVERRIDE_FIREHOSE_URL,
-      connectorName: _.kebabCase(manifest.name)
+      firehoseUrl: OVERRIDE_FIREHOSE_URL
     },
     cache: {
       store: "memory",

--- a/packages/connectors/hull-mailchimp/server/config.js
+++ b/packages/connectors/hull-mailchimp/server/config.js
@@ -1,6 +1,7 @@
 // @flow
 
 import type { HullConnectorConfig } from "hull";
+import _ from "lodash";
 import manifest from "../manifest.json";
 import handlers from "./handlers";
 

--- a/packages/connectors/hull-outreach/server/config.js
+++ b/packages/connectors/hull-outreach/server/config.js
@@ -1,7 +1,6 @@
 // @flow
 
 import type { HullConnectorConfig } from "hull";
-import _ from "lodash";
 import manifest from "../manifest.json";
 import handlers from "./handlers";
 
@@ -36,8 +35,7 @@ export default function connectorConfig(): HullConnectorConfig {
       logLevel: LOG_LEVEL
     },
     clientConfig: {
-      firehoseUrl: OVERRIDE_FIREHOSE_URL,
-      connectorName: _.kebabCase(manifest.name)
+      firehoseUrl: OVERRIDE_FIREHOSE_URL
     },
     serverConfig: {
       start: true

--- a/packages/connectors/hull-slack/server/config.js
+++ b/packages/connectors/hull-slack/server/config.js
@@ -1,7 +1,6 @@
 // @flow
 
 import type { HullConnectorConfig } from "hull";
-import _ from "lodash";
 import manifest from "../manifest.json";
 import handlers from "./handlers";
 
@@ -57,8 +56,7 @@ export default function connectorConfig(): HullConnectorConfig {
       devMode
     }),
     clientConfig: {
-      firehoseUrl: OVERRIDE_FIREHOSE_URL,
-      connectorName: _.kebabCase(manifest.name)
+      firehoseUrl: OVERRIDE_FIREHOSE_URL
     }
   };
 }

--- a/packages/connectors/hull-slack/server/config.js
+++ b/packages/connectors/hull-slack/server/config.js
@@ -1,6 +1,7 @@
 // @flow
 
 import type { HullConnectorConfig } from "hull";
+import _ from "lodash";
 import manifest from "../manifest.json";
 import handlers from "./handlers";
 

--- a/packages/connectors/hull-typeform/server/config.js
+++ b/packages/connectors/hull-typeform/server/config.js
@@ -1,7 +1,6 @@
 // @flow
 
 import type { HullConnectorConfig } from "hull";
-import _ from "lodash";
 import manifest from "../manifest.json";
 import handlers from "./handlers";
 
@@ -39,8 +38,7 @@ export default function connectorConfig(): HullConnectorConfig {
       logLevel: LOG_LEVEL
     },
     clientConfig: {
-      firehoseUrl: OVERRIDE_FIREHOSE_URL,
-      connectorName: _.kebabCase(manifest.name)
+      firehoseUrl: OVERRIDE_FIREHOSE_URL
     },
     serverConfig: {
       start: true

--- a/packages/hull/src/connector/hull-connector.js
+++ b/packages/hull/src/connector/hull-connector.js
@@ -1,6 +1,7 @@
 // @flow
 
 import type { $Application, Middleware } from "express";
+import _ from "lodash";
 import type { Server } from "http";
 import express from "express";
 import type {
@@ -154,7 +155,7 @@ class HullConnector {
       httpClientConfig,
       metricsConfig,
       logsConfig,
-      connectorName,
+      connectorName = _.kebabCase(manifest.name),
       middlewares = [],
       handlers,
       disableOnExit = false

--- a/packages/hull/test/integration/notification-handler-test.js
+++ b/packages/hull/test/integration/notification-handler-test.js
@@ -37,6 +37,7 @@ describe("notificationHandler", () => {
 
     app = express();
     connector = new Hull.Connector({
+      connectorName: "TestConnector",
       port: 9092,
       timeout: "100ms",
       skipSignatureValidation: true,

--- a/packages/hull/test/integration/notification-validation-test.js
+++ b/packages/hull/test/integration/notification-validation-test.js
@@ -36,6 +36,7 @@ const valid_notification = {
 
 let mockHttpClient = {};
 const connector = new Hull.Connector({
+  connectorName: "TestConnector",
   port: 9090,
   timeout: "100ms",
   hostSecret: "1234",


### PR DESCRIPTION
If we're going to have the same logic for all connectors, I suggest we avoid repeating it and find ways to centralize code.

This PR removes the redundant calls to define `connectorName` and moves it back to `hull-connector.js` -> it still leaves the option to override it on a per-connector basis