### PR TITLE
added logic to send if we do not have an id for the service, meaning …

### DIFF
--- a/packages/connectors/hull-hubspot/test/integration/scenarios/outgoing-user-complex-mapping.js
+++ b/packages/connectors/hull-hubspot/test/integration/scenarios/outgoing-user-complex-mapping.js
@@ -191,6 +191,13 @@ it("should send out a new hull user to hubspot with complex fields mapping", () 
         ["debug", "connector.service_api.call", expect.whatever(), expect.objectContaining({ "method": "POST", "status": 202, "url": "/contacts/v1/contact/batch/" })],
         [
           "info",
+          "outgoing.user.send",
+          expect.objectContaining({ "subject_type": "user", "user_email": "email@email.com"}),
+          {
+            reason: "does not have service id"
+          }],
+        [
+          "info",
           "outgoing.user.success",
           expect.objectContaining({ "subject_type": "user", "user_email": "email@email.com"}),
           {

--- a/packages/connectors/hull-hubspot/test/integration/scenarios/outgoing-user-mapped-account-attribute-change.js
+++ b/packages/connectors/hull-hubspot/test/integration/scenarios/outgoing-user-mapped-account-attribute-change.js
@@ -70,7 +70,8 @@ it("should allow through with mapped account attribute changes", () => {
             traits_custom_empty_string: "",
             traits_custom_zero: 0,
             // traits_custom_undefined: "", -> this is not present
-            traits_custom_date_at: "2018-10-24T09:47:39Z"
+            traits_custom_date_at: "2018-10-24T09:47:39Z",
+            "traits_hubspot/id": 5677
           },
           account: {
             id: "acc123",

--- a/packages/connectors/hull-hubspot/test/integration/scenarios/outgoing-user-unmapped-attribute-change.js
+++ b/packages/connectors/hull-hubspot/test/integration/scenarios/outgoing-user-unmapped-attribute-change.js
@@ -70,7 +70,8 @@ it("should filter because none of the mapped attributes have changed", () => {
             traits_custom_empty_string: "",
             traits_custom_zero: 0,
             // traits_custom_undefined: "", -> this is not present
-            traits_custom_date_at: "2018-10-24T09:47:39Z"
+            traits_custom_date_at: "2018-10-24T09:47:39Z",
+            "traits_hubspot/id": 1234
           },
           account: {
             id: "acc123",

--- a/packages/hull-connector-framework/src/purplefusion/utils.js
+++ b/packages/hull-connector-framework/src/purplefusion/utils.js
@@ -357,10 +357,23 @@ function toSendMessage(
   // or could be because it's a new connector which we haven't done a full fetch
   const serviceName = _.get(options, "serviceName");
   if (serviceName) {
-    console.log("servicename");
     const serviceId = _.get(message, `${targetEntity}.${serviceName}/id`);
-    console.log(serviceId);
     if (isUndefinedOrNull(serviceId)) {
+
+      // log for now so we can find this scenario
+      // remove after we've audited
+      try {
+        if (targetEntity === "user") {
+          context.client.asUser(entity).logger.info("outgoing.user.send", {
+            reason: "does not have service id"
+          });
+        } else if (targetEntity === "account") {
+          context.client.asAccount(entity).logger.info("outgoing.account.send", {
+            reason: "does not have service id"
+          });
+        }
+      } catch (error) {}
+
       return true;
     }
   }

--- a/packages/hull-connector-framework/src/purplefusion/utils.js
+++ b/packages/hull-connector-framework/src/purplefusion/utils.js
@@ -315,6 +315,8 @@ function toSendMessage(
     }
   }
 
+  // This is a special flag where we send all attributes regardless of change
+  // may want to reorder this in cases where we still may not want to send if an event comes through
   const send_all_user_attributes = _.get(context, "connector.private_settings.send_all_user_attributes");
   if (send_all_user_attributes === true && targetEntity === "user") {
     return true;
@@ -347,6 +349,20 @@ function toSendMessage(
       });
     }
     return false;
+  }
+
+  // in cases where we do not have a id of the service, which means we haven't sync'd the entity before
+  // send the user because we know it's in the list to send
+  // this may be the result of pushing a full segment after it's creation
+  // or could be because it's a new connector which we haven't done a full fetch
+  const serviceName = _.get(options, "serviceName");
+  if (serviceName) {
+    console.log("servicename");
+    const serviceId = _.get(message, `${targetEntity}.${serviceName}/id`);
+    console.log(serviceId);
+    if (isUndefinedOrNull(serviceId)) {
+      return true;
+    }
   }
 
   const attributesToSync = outgoingAttributes.map(attr => attr.hull);

--- a/packages/hull-connector-framework/test/unit/purplefusion-filter.spec.js
+++ b/packages/hull-connector-framework/test/unit/purplefusion-filter.spec.js
@@ -9,43 +9,43 @@ describe("Outgoing User Segment Filtering Tests", () => {
   it("outgoing user all segments", () => {
     const context = new ContextMock({ private_settings: { synchronized_user_segments: [ "ALL" ], send_all_user_attributes: true }});
     expect(toSendMessage(context,
-      "user", { segments: [], user: { email: "someuser@gmail.com"} })).toEqual(true)
+      "user", { segments: [], user: { email: "someuser@gmail.com"} })).toEqual(true);
   });
 
   it("outgoing user segment", () => {
     const context = new ContextMock({ private_settings: { synchronized_user_segments: [ "1234" ], send_all_user_attributes: true }});
     expect(toSendMessage(context,
-      "user", { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com"} })).toEqual(true)
+      "user", { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com"} })).toEqual(true);
   });
 
   it("outgoing user all segments account attribute change", () => {
     const context = new ContextMock({ private_settings: { synchronized_user_segments: [ "ALL" ], outgoing_user_attributes: [ {hull: "account.domain", service: "field" }] }});
     expect(toSendMessage(context,
-      "user", { segments: [], user: { email: "someuser@gmail.com"}, changes: { account: { domain: [null, "somedomain.com"]}} })).toEqual(true)
+      "user", { segments: [], user: { email: "someuser@gmail.com"}, changes: { account: { domain: [null, "somedomain.com"]}} })).toEqual(true);
   });
 
   it("outgoing user segment account attribute change", () => {
     const context = new ContextMock({ private_settings: { synchronized_user_segments: [ "1234" ], outgoing_user_attributes: [ {hull: "account.domain", service: "field" }] }});
     expect(toSendMessage(context,
-      "user", { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com"}, changes: { account: { domain: [null, "somedomain.com"]}} })).toEqual(true)
+      "user", { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com"}, changes: { account: { domain: [null, "somedomain.com"]}} })).toEqual(true);
   });
 
   it("outgoing user all segments user attribute change", () => {
     const context = new ContextMock({ private_settings: { synchronized_user_segments: [ "ALL" ], outgoing_user_attributes: [ {hull: "closeio/title", service: "field" }] }});
     expect(toSendMessage(context,
-      "user", { segments: [], user: { email: "someuser@gmail.com"}, changes: { user: { "closeio/title": [null, "sometitle"]}} })).toEqual(true)
+      "user", { segments: [], user: { email: "someuser@gmail.com"}, changes: { user: { "closeio/title": [null, "sometitle"]}} })).toEqual(true);
   });
 
   it("outgoing user segment user attribute change", () => {
     const context = new ContextMock({ private_settings: { synchronized_user_segments: [ "1234" ], outgoing_user_attributes: [ {hull: "closeio/title", service: "field" }] }});
     expect(toSendMessage(context,
-      "user", { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com"}, changes: { user: { "closeio/title": [null, "sometitle"]}} })).toEqual(true)
+      "user", { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com"}, changes: { user: { "closeio/title": [null, "sometitle"]}} })).toEqual(true);
   });
 
   it("outgoing user entered segment", () => {
     const context = new ContextMock({ private_settings: { synchronized_user_segments: [ "1234" ] }});
     expect(toSendMessage(context,
-      "user", { segments: [ ], user: { email: "someuser@gmail.com"}, changes: { segments: { entered: [ { id: "1234" }]}} })).toEqual(true)
+      "user", { segments: [ ], user: { email: "someuser@gmail.com"}, changes: { segments: { entered: [ { id: "1234" }]}} })).toEqual(true);
   });
 
 
@@ -55,21 +55,21 @@ describe("Outgoing User Segment Filtering Tests", () => {
     expect(toSendMessage(context,
       "user",
       { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com"}, changes: { segments: { entered: [ { id: "1234" }]}} },
-      { sendOnAnySegmentChanges: true })).toEqual(true)
+      { sendOnAnySegmentChanges: true })).toEqual(true);
   });
 
   it("outgoing user send on sendOnAnySegmentChanges option(left), for synching hull_segments", () => {
     const context = new ContextMock({ private_settings: { synchronized_user_segments: [ "1234" ] }});
     expect(toSendMessage(context,
       "user", { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com"}, changes: { segments: { left: [ { id: "1234" }]}} },
-      { sendOnAnySegmentChanges: true })).toEqual(true)
+      { sendOnAnySegmentChanges: true })).toEqual(true);
   });
 
   it("outgoing user send on sendOnAnySegmentChanges option, no changed segments", () => {
     const context = new ContextMock({ private_settings: { synchronized_user_segments: [ "1234" ] }});
     expect(toSendMessage(context,
       "user", { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com"}, changes: { account: { domain: [null, "somedomain.com"]}} },
-      { sendOnAnySegmentChanges: true })).toEqual(false)
+      { sendOnAnySegmentChanges: true })).toEqual(false);
   });
 
   //testing on account link changes (different identifiers can be an account link change)
@@ -77,33 +77,33 @@ describe("Outgoing User Segment Filtering Tests", () => {
     const context = new ContextMock({ private_settings: { synchronized_user_segments: [ "1234" ], link_users_in_service: true }});
     expect(toSendMessage(context,
       "user", { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com"}, changes: { account: { id: [null, "1234"]}} },
-      { sendOnAnySegmentChanges: true })).toEqual(true)
+      { sendOnAnySegmentChanges: true })).toEqual(true);
   });
 
   it("outgoing user service account id changes", () => {
     const context = new ContextMock({ private_settings: { synchronized_user_segments: [ "1234" ], link_users_in_service: true }});
     expect(toSendMessage(context,
       "user", { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com"}, changes: { account: { "hubspot/id": [null, "1234"]}} },
-      { serviceName: "hubspot" })).toEqual(true)
+      { serviceName: "hubspot" })).toEqual(true);
   });
 
   // must specify a service name to know what attribute to check on the account
   it("outgoing user service account id changes, but no serviceName specified", () => {
     const context = new ContextMock({ private_settings: { synchronized_user_segments: [ "1234" ], link_users_in_service: true }});
     expect(toSendMessage(context,
-      "user", { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com"}, changes: { account: { "hubspot/id": [null, "1234"]}} })).toEqual(false)
+      "user", { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com"}, changes: { account: { "hubspot/id": [null, "1234"]}} })).toEqual(false);
   });
 
   it("outgoing user specified associated account id changes at account level", () => {
     const context = new ContextMock({ private_settings: { synchronized_user_segments: [ "1234" ], outgoing_user_associated_account_id: "account.salesforce/someid" }});
     expect(toSendMessage(context,
-      "user", { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com"}, changes: { account: { "salesforce/someid": ["asdf", "1234"]}} })).toEqual(true)
+      "user", { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com"}, changes: { account: { "salesforce/someid": ["asdf", "1234"]}} })).toEqual(true);
   });
 
   it("outgoing user specified associated account id changes at user level", () => {
     const context = new ContextMock({ private_settings: { synchronized_user_segments: [ "1234" ], outgoing_user_associated_account_id: "salesforce/someid" }});
     expect(toSendMessage(context,
-      "user", { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com"}, changes: { user: { "salesforce/someid": ["asdf", "1234"]}} })).toEqual(true)
+      "user", { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com"}, changes: { user: { "salesforce/someid": ["asdf", "1234"]}} })).toEqual(true);
   });
 
 
@@ -111,31 +111,54 @@ describe("Outgoing User Segment Filtering Tests", () => {
   it("outgoing user all segments no attribute changes", () => {
     const context = new ContextMock({ private_settings: { synchronized_user_segments: [ "ALL" ] }});
     expect(toSendMessage(context,
-      "user", { segments: [], user: { email: "someuser@gmail.com"} })).toEqual(false)
+      "user", { segments: [], user: { email: "someuser@gmail.com"} })).toEqual(false);
   });
 
   it("outgoing user segment no attribute changes", () => {
     const context = new ContextMock({ private_settings: { synchronized_user_segments: [ "1234" ] }});
     expect(toSendMessage(context,
-      "user", { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com"} })).toEqual(false)
+      "user", { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com"} })).toEqual(false);
   });
 
   it("outgoing user all segments different account attribute change", () => {
     const context = new ContextMock({ private_settings: { synchronized_user_segments: [ "ALL" ], outgoing_user_attributes: [ {hull: "account.closeio/status", service: "field" }] }});
     expect(toSendMessage(context,
-      "user", { segments: [], user: { email: "someuser@gmail.com"}, changes: { account: { domain: [null, "somedomain.com"]}} })).toEqual(false)
+      "user", { segments: [], user: { email: "someuser@gmail.com"}, changes: { account: { domain: [null, "somedomain.com"]}} })).toEqual(false);
   });
 
   it("outgoing user segment account attribute change", () => {
     const context = new ContextMock({ private_settings: { synchronized_user_segments: [ "1234" ], outgoing_user_attributes: [ {hull: "account.closeio/status", service: "field" }] }});
     expect(toSendMessage(context,
-      "user", { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com"}, changes: { account: { domain: [null, "somedomain.com"]}} })).toEqual(false)
+      "user", { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com"}, changes: { account: { domain: [null, "somedomain.com"]}} })).toEqual(false);
   });
 
   it("outgoing user entered not synchronized segment", () => {
     const context = new ContextMock({ private_settings: { synchronized_user_segments: [ "1234" ] }});
     expect(toSendMessage(context,
-      "user", { segments: [ ], user: { email: "someuser@gmail.com"}, changes: { segments: { entered: [ { id: "567" }]}} })).toEqual(false)
+      "user", { segments: [ ], user: { email: "someuser@gmail.com"}, changes: { segments: { entered: [ { id: "567" }]}} })).toEqual(false);
+  });
+
+  it("outgoing user is has not been sync'd with service yet, does not have service id, so push it", () => {
+    const context = new ContextMock({ private_settings: { synchronized_user_segments: [ "1234" ], outgoing_user_attributes: [ {hull: "closeio/title", service: "field" }] }});
+    expect(toSendMessage(context,
+      "user", { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com"} },
+      { "serviceName": "hubspot" })).toEqual(true);
+  });
+
+  it("outgoing user has a service id, but no changes, so don't sync", () => {
+    const context = new ContextMock({ private_settings: { synchronized_user_segments: [ "1234" ], outgoing_user_attributes: [ {hull: "closeio/title", service: "field" }] }});
+    expect(toSendMessage(context,
+      "user", { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com", "hubspot/id": 5678 } },
+      { "serviceName": "hubspot" })).toEqual(false);
+  });
+
+  // Edge case, in the future we may decide to send this maybe, but no outgoing attributes...
+  // but is in segment
+  it("outgoing user is has not been sync'd with service yet, is in a synchronized segment, has no outgoing attributes, does not have service id, so push it", () => {
+    const context = new ContextMock({ private_settings: { synchronized_user_segments: [ "1234" ], outgoing_user_attributes: [ ] }});
+    expect(toSendMessage(context,
+      "user", { segments: [ { id: "1234" } ], user: { email: "someuser@gmail.com"} },
+      { "serviceName": "hubspot" })).toEqual(false);
   });
 
 
@@ -146,32 +169,32 @@ describe("Outgoing Account Segment Filtering Tests", () => {
   it("outgoing account all segments", () => {
     const context = new ContextMock({ private_settings: { synchronized_account_segments: [ "ALL" ], send_all_account_attributes: true }});
     expect(toSendMessage(context,
-      "account", { account_segments: [], account: { domain: "somedomain.com"} })).toEqual(true)
+      "account", { account_segments: [], account: { domain: "somedomain.com"} })).toEqual(true);
   });
 
   it("outgoing account segment", () => {
     const context = new ContextMock({ private_settings: { synchronized_account_segments: [ "1234" ], send_all_account_attributes: true }});
     expect(toSendMessage(context,
-      "account", { account_segments: [ { id: "1234" } ], account: { email: "somedomain.com"} })).toEqual(true)
+      "account", { account_segments: [ { id: "1234" } ], account: { email: "somedomain.com"} })).toEqual(true);
   });
 
   it("outgoing account all segments account attribute change", () => {
     const context = new ContextMock({ private_settings: { synchronized_account_segments: [ "ALL" ], outgoing_account_attributes: [ {hull: "domain", service: "field" }] }});
     expect(toSendMessage(context,
-      "account", { account_segments: [], account: { domain: "somedomain.com"}, changes: { account: { domain: [null, "somedomain.com"]}} })).toEqual(true)
+      "account", { account_segments: [], account: { domain: "somedomain.com"}, changes: { account: { domain: [null, "somedomain.com"]}} })).toEqual(true);
   });
 
   it("outgoing account segment account attribute change", () => {
     const context = new ContextMock({ private_settings: { synchronized_account_segments: [ "1234" ], outgoing_account_attributes: [ {hull: "domain", service: "field" }] }});
     expect(toSendMessage(context,
-      "account", { account_segments: [ { id: "1234" } ], account: { domain: "somedomain.com"}, changes: { account: { domain: [null, "somedomain.com"]}} })).toEqual(true)
+      "account", { account_segments: [ { id: "1234" } ], account: { domain: "somedomain.com"}, changes: { account: { domain: [null, "somedomain.com"]}} })).toEqual(true);
   });
 
 
   it("outgoing account entered segment", () => {
     const context = new ContextMock({ private_settings: { synchronized_account_segments: [ "1234" ] }});
     expect(toSendMessage(context,
-      "account", { account_segments: [ ], account: { domain: "somedomain.com"}, changes: { account_segments: { entered: [ { id: "1234" }]}} })).toEqual(true)
+      "account", { account_segments: [ ], account: { domain: "somedomain.com"}, changes: { account_segments: { entered: [ { id: "1234" }]}} })).toEqual(true);
   });
 
 
@@ -181,21 +204,21 @@ describe("Outgoing Account Segment Filtering Tests", () => {
     expect(toSendMessage(context,
       "account",
       { account_segments: [ { id: "1234" } ], account: { domain: "somedomain.com"}, changes: { account_segments: { entered: [ { id: "5678" }]}} },
-      { sendOnAnySegmentChanges: true })).toEqual(true)
+      { sendOnAnySegmentChanges: true })).toEqual(true);
   });
 
   it("outgoing account send on sendOnAnySegmentChanges option(left), for synching hull_segments", () => {
     const context = new ContextMock({ private_settings: { synchronized_account_segments: [ "1234" ] }});
     expect(toSendMessage(context,
       "account", { account_segments: [ { id: "1234" } ], account: { domain: "somedomain.com"}, changes: { account_segments: { left: [ { id: "5678" }]}} },
-      { sendOnAnySegmentChanges: true })).toEqual(true)
+      { sendOnAnySegmentChanges: true })).toEqual(true);
   });
 
   it("outgoing account send on sendOnAnySegmentChanges option, no changed segments", () => {
     const context = new ContextMock({ private_settings: { synchronized_account_segments: [ "1234" ] }});
     expect(toSendMessage(context,
       "account", { account_segments: [ { id: "1234" } ], account: { domain: "somedomain.com"}, changes: { account: { domain: [null, "somedomain.com"]}} },
-      { sendOnAnySegmentChanges: true })).toEqual(false)
+      { sendOnAnySegmentChanges: true })).toEqual(false);
   });
 
 
@@ -203,25 +226,39 @@ describe("Outgoing Account Segment Filtering Tests", () => {
   it("outgoing account all segments no attribute changes", () => {
     const context = new ContextMock({ private_settings: { synchronized_account_segments: [ "ALL" ] }});
     expect(toSendMessage(context,
-      "account", { account_segments: [ ], account: { domain: "somedomain.com"} })).toEqual(false)
+      "account", { account_segments: [ ], account: { domain: "somedomain.com"} })).toEqual(false);
   });
 
   it("outgoing account segment no attribute changes", () => {
     const context = new ContextMock({ private_settings: { synchronized_account_segments: [ "1234" ] }});
     expect(toSendMessage(context,
-      "account", { account_segments: [ { id: "1234" } ], account: { domain: "somedomain.com"} })).toEqual(false)
+      "account", { account_segments: [ { id: "1234" } ], account: { domain: "somedomain.com"} })).toEqual(false);
   });
 
   it("outgoing  all segments different attribute change", () => {
     const context = new ContextMock({ private_settings: { synchronized_account_segments: [ "ALL" ], outgoing_account_attributes: [ {hull: "closeio/status", service: "field" }] }});
     expect(toSendMessage(context,
-      "account", { account_segments: [], account: { domain: "somedomain.com"}, changes: { account: { domain: [null, "somedomain.com"]}} })).toEqual(false)
+      "account", { account_segments: [], account: { domain: "somedomain.com"}, changes: { account: { domain: [null, "somedomain.com"]}} })).toEqual(false);
   });
 
   it("outgoing account entered not synchronized segment", () => {
     const context = new ContextMock({ private_settings: { synchronized_account_segments: [ "1234" ] }});
     expect(toSendMessage(context,
-      "account", { account_segments: [ "1234" ], account: { domain: "somedomain.com"}, changes: { segments: { entered: [ { id: "567" }]}} })).toEqual(false)
+      "account", { account_segments: [ "1234" ], account: { domain: "somedomain.com"}, changes: { segments: { entered: [ { id: "567" }]}} })).toEqual(false);
+  });
+
+  it("outgoing account does not have service id, but is in segment so push", () => {
+    const context = new ContextMock({ private_settings: { synchronized_account_segments: [ "1234" ], outgoing_account_attributes: [ {hull: "domain", service: "field" }] }});
+    expect(toSendMessage(context,
+      "account", { account_segments: [ { id: "1234" } ], account: { domain: "somedomain.com"} },
+      { "serviceName": "hubspot" })).toEqual(true);
+  });
+
+  it("outgoing account has service id, but no changes, so don't push", () => {
+    const context = new ContextMock({ private_settings: { synchronized_account_segments: [ "1234" ], outgoing_account_attributes: [ {hull: "domain", service: "field" }] }});
+    expect(toSendMessage(context,
+      "account", { account_segments: [ { id: "1234" } ], account: { domain: "somedomain.com", "hubspot/id": 5678} },
+      { "serviceName": "hubspot" })).toEqual(false);
   });
 
 


### PR DESCRIPTION
Look at all that beautiful filter logic in 1 place, with unit tests.  In production only logging for hubspot