### PR TITLE
Use has_parent query instead of deprecated terms query on _parent field

### DIFF
--- a/packages/hull/src/utils/get-entity.js
+++ b/packages/hull/src/utils/get-entity.js
@@ -55,12 +55,18 @@ export const searchEvents = (ctx: HullContext) => async ({
   page = 1,
   per_page = 50
 }: HullIncludedEvents & { parent: string }): Promise<Array<HullEvent>> => {
-  const query = [{
-    has_parent: {
-      parent_type: "user_report",
-      query: { term: { id: parent } }
+  const query = [
+    {
+      has_parent: {
+        parent_type: "user_report",
+        query: {
+          term: {
+            id: parent
+          }
+        }
+      }
     }
-  }];
+  ];
   if (_.isArray(names)) {
     query.push({ terms: { event: names } });
   }

--- a/packages/hull/src/utils/get-entity.js
+++ b/packages/hull/src/utils/get-entity.js
@@ -55,7 +55,12 @@ export const searchEvents = (ctx: HullContext) => async ({
   page = 1,
   per_page = 50
 }: HullIncludedEvents & { parent: string }): Promise<Array<HullEvent>> => {
-  const query = [{ term: { _parent: parent } }];
+  const query = [{
+    has_parent: {
+      parent_type: "user_report",
+      query: { term: { id: parent } }
+    }
+  }];
   if (_.isArray(names)) {
     query.push({ terms: { event: names } });
   }


### PR DESCRIPTION
This PR is important to fix a deprecation issue when indices are migrated to ES5