### PR TITLE
fixed call to settings update to pass refresh status

### DIFF
--- a/packages/hull/src/helpers/settings-update.js
+++ b/packages/hull/src/helpers/settings-update.js
@@ -20,11 +20,9 @@ const {
  * @example
  * req.hull.helpers.settingsUpdate({ newSettings }, refreshStatus);
  */
-const settingsUpdate = (
-  ctx: HullContext,
+const settingsUpdate = (ctx: HullContext) => async (
+  newSettings: $PropertyType<HullConnector, "private_settings">,
   refreshStatus: Boolean = false
-) => async (
-  newSettings: $PropertyType<HullConnector, "private_settings">
 ): void | Promise<HullConnector> => {
   const { client, cache, connector } = ctx;
   try {

--- a/packages/hull/test/unit/helpers/settings-update-test.js
+++ b/packages/hull/test/unit/helpers/settings-update-test.js
@@ -27,7 +27,7 @@ describe("settingsUpdate", () => {
           settings: { update: updateStub }
         }
       }
-    }, true)({});
+    })({}, true);
     expect(updateStub.called).to.be.ok;
     expect(updateStub.calledWith({}, true)).to.be.true;
   });


### PR DESCRIPTION
Problem:

The boolean "true" is not being passed properly as refreshStatus.  Based on the settingsUpdate method, it should be passed when the factory method is invoked:

[https://github.com/hull/hull-connectors/blob/master/packages/hull/src/helpers/settings-update.js#L25](https://github.com/hull/hull-connectors/blob/master/packages/hull/src/helpers/settings-update.js#L25)

But the original factory call is made in the client-middleware.js, which does not include "refreshStatus",  Probably we don't have enough information at that point to know whether to pass it or not.
[https://github.com/hull/hull-connectors/blob/master/packages/hull/src/middlewares/client-middleware.js#L63](https://github.com/hull/hull-connectors/blob/master/packages/hull/src/middlewares/client-middleware.js#L63)

```f(req.hull)```

Solution:

Take the refreshStatus out of the factory method that creates the settingsUpdate method, and move it to the actual method call