### PR TITLE
Ignore identical Dates in VM Dedupes

### DIFF
--- a/packages/connectors/hull-processor/test/integration/scenarios/compute.js
+++ b/packages/connectors/hull-processor/test/integration/scenarios/compute.js
@@ -197,7 +197,11 @@ describe("Basic Attributes manipulation", () => {
     const asAccount = {
       id: "1234"
     };
-    const attributes = { identical: "value" };
+    const attributes = {
+      identical: "value",
+      identical_date: "2020-08-06T16:56:59+02:00"
+    };
+    const identical_date = "2020-08-06T17:56:59+03:00";
     return testScenario({ connectorConfig }, ({ handlers, nock, expect }) => ({
       ...messageWithUser({
         user: {
@@ -207,7 +211,9 @@ describe("Basic Attributes manipulation", () => {
         account: {}
       }),
       handlerType: handlers.notificationHandler,
-      connector: connectorWithCode(`hull.traits({ identical: "value" })`),
+      connector: connectorWithCode(
+        `hull.traits({ identical: "value", identical_date: "${identical_date}" })`
+      ),
       firehoseEvents: [],
       logs: [
         [
@@ -215,14 +221,20 @@ describe("Basic Attributes manipulation", () => {
           "compute.debug",
           expect.whatever(),
           expect.objectContaining({
-            userTraits: [[asUser, attributes]]
+            userTraits: [[asUser, { ...attributes, identical_date }]]
           })
         ],
         [
           "debug",
           "incoming.user.success",
           expect.whatever(),
-          { attributes: {}, no_ops: { identical: "identical value" } }
+          {
+            attributes: {},
+            no_ops: {
+              identical: "identical value",
+              identical_date: "identical date"
+            }
+          }
         ]
       ],
       metrics: [METRIC_CONNECTOR_REQUEST, METRIC_INCOMING_USER]

--- a/packages/hull-vm/server/side-effects.js
+++ b/packages/hull-vm/server/side-effects.js
@@ -2,6 +2,7 @@
 import type { HullUser, HullAccount, HullClient, HullContext } from "hull";
 import _ from "lodash";
 import { Map } from "immutable";
+import moment from "moment";
 import type { Result, Event } from "../types";
 
 type TraitsSignature =
@@ -81,6 +82,14 @@ export const callTraits = async ({
             // Lodash allows deep object comparison
             if (_.isEqual(previous, v)) {
               no_ops[k] = "identical value";
+              return true;
+            }
+            if (
+              // $FlowFixMe
+              (k.endsWith("_date") || k.endsWith("_at")) &&
+              moment(previous).isSame(moment(v))
+            ) {
+              no_ops[k] = "identical date";
               return true;
             }
             return false;


### PR DESCRIPTION
Adds support for comparing `_date` and `_at` attribute actual Dates using Moment to define if we want to skip updating them