### PR TITLE
updated description to be more accurate

### DIFF
--- a/packages/connectors/hull-clearbit/manifest.json
+++ b/packages/connectors/hull-clearbit/manifest.json
@@ -1497,7 +1497,7 @@
     },
     {
       "title": "User Reveal whitelist",
-      "description": "Who will be sent to Reveal. *Every anonymous user is sent if this is empty*. We never send anyone who has identifiable information",
+      "description": "Who will be sent to Reveal.",
       "name": "reveal_user_segments",
       "type": "array",
       "default": [],


### PR DESCRIPTION
Based on what I read here: 

https://github.com/hull/hull-connectors/blob/hotfix/update-clearbit-doc/packages/connectors/hull-clearbit/server/clearbit/reveal.js#L37

If the segment is empty we send no one. Not sure how we're "Not sending anyone with identifiable information" either... but must be in there somewhere... How should this actually be setup?